### PR TITLE
fix: remove wrong test

### DIFF
--- a/server/test/testHT8.js
+++ b/server/test/testHT8.js
@@ -198,21 +198,4 @@ describe('Test API for adding huts or parking as startPoint/arrivals', () => {
         expect(response.statusCode).to.equal(400);
     });
 
-    it('test causing db error',async()=>{
-        const token = localGuide.token;
-
-        const hike = await Hike.findById(new mongoose.Types.ObjectId('0000000194e4c1e796231d9a'));
-        const parkHut = true;
-
-        const response = await request(app)
-        .put("/linkStartArrival")
-        .set('Authorization', "Bearer " + token)
-        .send({
-            point: "end",
-            reference: "parking",
-            id: parkHut,
-            hikeId: hike.id
-        });
-        expect(response.statusCode).to.equal(500);
-    });
 });


### PR DESCRIPTION
This test failing and returning 500 proves that the /linkStartArrival endpoint has a bug. If you assign parkHut to true and send the request, the endpoint should detect the wrong parameter and return a 400 (Bad Request) status code. The endpoint launching 500 (Internal Server Error) is incorrect. 500 is for unexpected errors